### PR TITLE
Handle case when a container has null `.NetworkSettings.Ports`

### DIFF
--- a/nuntio-platform-docker/src/main/java/eu/xenit/nuntio/platform/docker/config/parser/InspectContainerMetadata.java
+++ b/nuntio-platform-docker/src/main/java/eu/xenit/nuntio/platform/docker/config/parser/InspectContainerMetadata.java
@@ -1,10 +1,13 @@
 package eu.xenit.nuntio.platform.docker.config.parser;
 
+import com.github.dockerjava.api.model.NetworkSettings;
+import com.github.dockerjava.api.model.Ports;
 import eu.xenit.nuntio.api.platform.ServiceBinding;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -21,9 +24,11 @@ public class InspectContainerMetadata implements ContainerMetadata {
 
     @Override
     public Set<ServiceBinding> getInternalPortBindings() {
-        return inspectContainerResponse.getNetworkSettings().getPorts()
-                .getBindings()
-                .keySet()
+        return Optional.ofNullable(inspectContainerResponse.getNetworkSettings())
+                .map(NetworkSettings::getPorts)
+                .map(Ports::getBindings)
+                .map(Map::keySet)
+                .orElse(Collections.emptySet())
                 .stream()
                 .map(exposedPort -> ServiceBinding.fromPortAndProtocol(exposedPort.getPort(), exposedPort.getProtocol().toString()))
                 .collect(Collectors.toSet());

--- a/nuntio-platform-docker/src/test/java/eu/xenit/nuntio/platform/docker/config/parser/InspectContainerMetadataTest.java
+++ b/nuntio-platform-docker/src/test/java/eu/xenit/nuntio/platform/docker/config/parser/InspectContainerMetadataTest.java
@@ -11,6 +11,7 @@ import com.github.dockerjava.api.model.NetworkSettings;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.Ports.Binding;
 import eu.xenit.nuntio.api.platform.ServiceBinding;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,6 +75,13 @@ class InspectContainerMetadataTest {
                 "EMPTY", "",
                 "triple", "equals=sign"
         ), inspectContainerMetadata.getEnvironment());
+    }
+
+    @Test
+    void noPorts() {
+        when(networkSettings.getPorts()).thenReturn(null);
+
+        assertEquals(Collections.emptySet(), inspectContainerMetadata.getInternalPortBindings());
     }
 
 }


### PR DESCRIPTION
When a container is in state `restarting` or `created`, the
`.NetworkSettings.Ports` property is `null` instead of an empty object.

Fixes #8 