### PR TITLE
Allow use of fake registry & platforms to debug issues, improve logs to make debugging easier

### DIFF
--- a/nuntio-app/build.gradle
+++ b/nuntio-app/build.gradle
@@ -13,6 +13,7 @@ plugins {
 dependencies {
     implementation project(':nuntio-integration')
     implementation project(':nuntio-platform-docker')
+    implementation project(':nuntio-platform-fake')
     implementation project(':nuntio-registry-consul')
     implementation project(':nuntio-registry-fake')
     implementation 'org.springframework.boot:spring-boot-starter'

--- a/nuntio-app/src/main/java/eu/xenit/nuntio/app/NuntioCoreApplication.java
+++ b/nuntio-app/src/main/java/eu/xenit/nuntio/app/NuntioCoreApplication.java
@@ -1,18 +1,11 @@
 package eu.xenit.nuntio.app;
 
 import eu.xenit.nuntio.integration.EnableNuntio;
-import eu.xenit.nuntio.platform.docker.DockerConfiguration;
-import eu.xenit.nuntio.registry.consul.ConsulConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
 @EnableNuntio
-@Import({
-        DockerConfiguration.class,
-        ConsulConfiguration.class
-})
 public class NuntioCoreApplication {
 
     public static void main(String[] args) {

--- a/nuntio-platform-docker/src/main/java/eu/xenit/nuntio/platform/docker/config/parser/ContainerMetadata.java
+++ b/nuntio-platform-docker/src/main/java/eu/xenit/nuntio/platform/docker/config/parser/ContainerMetadata.java
@@ -6,6 +6,8 @@ import java.util.Set;
 
 public interface ContainerMetadata {
 
+    String getContainerName();
+
     String getImageName();
 
     Set<ServiceBinding> getExposedPortBindings();

--- a/nuntio-platform-docker/src/main/java/eu/xenit/nuntio/platform/docker/config/parser/InspectContainerMetadata.java
+++ b/nuntio-platform-docker/src/main/java/eu/xenit/nuntio/platform/docker/config/parser/InspectContainerMetadata.java
@@ -1,9 +1,9 @@
 package eu.xenit.nuntio.platform.docker.config.parser;
 
+import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.NetworkSettings;
 import com.github.dockerjava.api.model.Ports;
 import eu.xenit.nuntio.api.platform.ServiceBinding;
-import com.github.dockerjava.api.command.InspectContainerResponse;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +17,11 @@ import lombok.AllArgsConstructor;
 public class InspectContainerMetadata implements ContainerMetadata {
 
     private final InspectContainerResponse inspectContainerResponse;
+
+    @Override
+    public String getContainerName() {
+        return inspectContainerResponse.getName().substring(1);
+    }
 
     @Override
     public String getImageName() {

--- a/nuntio-platform-docker/src/main/java/eu/xenit/nuntio/platform/docker/config/parser/RegistratorCompatibleParser.java
+++ b/nuntio-platform-docker/src/main/java/eu/xenit/nuntio/platform/docker/config/parser/RegistratorCompatibleParser.java
@@ -38,6 +38,7 @@ public class RegistratorCompatibleParser implements ServiceConfigurationParser {
         configuration.putAll(containerMetadata.getLabels());
 
         Set<ServiceBinding> serviceBindings = portBindConfiguration == PortBindConfiguration.INTERNAL?containerMetadata.getExposedPortBindings():containerMetadata.getPublishedPortBindings();
+        log.debug("Container {} has relevant service bindings {}", containerMetadata, serviceBindings);
         boolean hasMultipleBindings = serviceBindings.size() > 1;
 
         Set<PlatformServiceConfiguration> platformServiceConfigurations = new HashSet<>();
@@ -69,6 +70,11 @@ public class RegistratorCompatibleParser implements ServiceConfigurationParser {
                 continue;
             }
             String serviceName = maybeServiceName.orElseGet(() -> extractImageBaseName(containerMetadata.getImageName()) + defaultServiceNameSuffix);
+            if(maybeServiceName.isEmpty()) {
+                log.debug("Automatically set service name of container {} with binding {} to {} based on image name", containerMetadata, serviceBinding, serviceName);
+            } else {
+                log.debug("Service name for container {} with binding {} is {}", containerMetadata, serviceBinding, serviceName);
+            }
 
             platformServiceBuilder.serviceName(serviceName);
 

--- a/nuntio-platform-docker/src/main/java/eu/xenit/nuntio/platform/docker/config/parser/RegistratorCompatibleParser.java
+++ b/nuntio-platform-docker/src/main/java/eu/xenit/nuntio/platform/docker/config/parser/RegistratorCompatibleParser.java
@@ -2,7 +2,6 @@ package eu.xenit.nuntio.platform.docker.config.parser;
 
 import eu.xenit.nuntio.api.platform.PlatformServiceConfiguration;
 import eu.xenit.nuntio.api.platform.ServiceBinding;
-import eu.xenit.nuntio.platform.docker.DockerProperties;
 import eu.xenit.nuntio.platform.docker.DockerProperties.PortBindConfiguration;
 import eu.xenit.nuntio.platform.docker.DockerProperties.RegistratorCompatibleProperties;
 import java.util.HashMap;
@@ -16,6 +15,8 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -31,6 +32,19 @@ public class RegistratorCompatibleParser implements ServiceConfigurationParser {
     PortBindConfiguration portBindConfiguration;
     RegistratorCompatibleProperties registratorCompatibleProperties;
 
+    @Value
+    @ToString(onlyExplicitlyIncluded = true)
+    private static class ContainerWithServiceBinding {
+        ContainerMetadata containerMetadata;
+        @ToString.Include
+        ServiceBinding serviceBinding;
+
+        @ToString.Include(name = "container", rank = 1)
+        private String getContainerName() {
+            return containerMetadata.getContainerName();
+        }
+    }
+
     @Override
     public Set<PlatformServiceConfiguration> toServiceConfigurations(ContainerMetadata containerMetadata) {
         Map<String, String> configuration = new HashMap<>();
@@ -38,17 +52,18 @@ public class RegistratorCompatibleParser implements ServiceConfigurationParser {
         configuration.putAll(containerMetadata.getLabels());
 
         Set<ServiceBinding> serviceBindings = portBindConfiguration == PortBindConfiguration.INTERNAL?containerMetadata.getExposedPortBindings():containerMetadata.getPublishedPortBindings();
-        log.debug("Container {} has relevant service bindings {}", containerMetadata, serviceBindings);
+        log.debug("Container {} has relevant service bindings {}", containerMetadata.getContainerName(), serviceBindings);
         boolean hasMultipleBindings = serviceBindings.size() > 1;
 
         Set<PlatformServiceConfiguration> platformServiceConfigurations = new HashSet<>();
         for(ServiceBinding serviceBinding: serviceBindings) {
+            ContainerWithServiceBinding containerWithServiceBinding = new ContainerWithServiceBinding(containerMetadata, serviceBinding);
             // If SERVICE_<port>_IGNORE or SERVICE_IGNORE is present and not empty, disregard this service
             boolean isIgnore = findValueWithFallback(ConfigKind.IGNORE, serviceBinding, configuration)
                     .filter(Predicate.not(String::isEmpty))
                     .isPresent();
             if(isIgnore) {
-                log.debug("Service binding {} is ignored", serviceBinding);
+                log.debug("{} is ignored", containerWithServiceBinding);
                 continue;
             }
 
@@ -64,16 +79,16 @@ public class RegistratorCompatibleParser implements ServiceConfigurationParser {
                     .or(() -> findValue(ConfigKind.SERVICE_NAME, ServiceBinding.ANY, configuration)
                             .map(defaultServiceName -> defaultServiceName + defaultServiceNameSuffix)
                     );
-            // Configurable deviation from registrator behavior to ignore containers by default
+            // Registrator explicit mode: ignore containers unless SERVICE_NAME is set
             if(registratorCompatibleProperties.isExplicit() && maybeServiceName.isEmpty()) {
-                log.debug("Service binding {} is ignored because no service name is configured", serviceBinding);
+                log.debug("{} is ignored because no service name is configured", containerWithServiceBinding);
                 continue;
             }
             String serviceName = maybeServiceName.orElseGet(() -> extractImageBaseName(containerMetadata.getImageName()) + defaultServiceNameSuffix);
             if(maybeServiceName.isEmpty()) {
-                log.debug("Automatically set service name of container {} with binding {} to {} based on image name", containerMetadata, serviceBinding, serviceName);
+                log.debug("Automatically set service name of {} to {} based on image name", containerWithServiceBinding, serviceName);
             } else {
-                log.debug("Service name for container {} with binding {} is {}", containerMetadata, serviceBinding, serviceName);
+                log.debug("Service name for {} is {}", containerWithServiceBinding, serviceName);
             }
 
             platformServiceBuilder.serviceName(serviceName);

--- a/nuntio-platform-docker/src/main/resources/META-INF/spring.factories
+++ b/nuntio-platform-docker/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=eu.xenit.nuntio.platform.docker.DockerConfiguration

--- a/nuntio-platform-docker/src/test/java/eu/xenit/nuntio/platform/docker/config/parser/SimpleContainerMetadata.java
+++ b/nuntio-platform-docker/src/test/java/eu/xenit/nuntio/platform/docker/config/parser/SimpleContainerMetadata.java
@@ -12,6 +12,7 @@ import lombok.Value;
 @Value
 @Builder
 public class SimpleContainerMetadata implements ContainerMetadata{
+    String containerName;
     String imageName;
     @Singular
     Set<ServiceBinding> exposedPortBindings;

--- a/nuntio-platform-fake/src/main/java/eu/xenit/nuntio/platform/fake/FakePlatformConfiguration.java
+++ b/nuntio-platform-fake/src/main/java/eu/xenit/nuntio/platform/fake/FakePlatformConfiguration.java
@@ -1,9 +1,15 @@
 package eu.xenit.nuntio.platform.fake;
 
+import eu.xenit.nuntio.api.platform.ServicePlatform;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 
 @Configuration
+@ConditionalOnMissingBean(ServicePlatform.class)
+@AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
 public class FakePlatformConfiguration {
 
     @Bean

--- a/nuntio-platform-fake/src/main/resources/META-INF/spring.factories
+++ b/nuntio-platform-fake/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=eu.xenit.nuntio.platform.fake.FakePlatformConfiguration

--- a/nuntio-registry-consul/src/main/java/eu/xenit/nuntio/registry/consul/ConsulRegistry.java
+++ b/nuntio-registry-consul/src/main/java/eu/xenit/nuntio/registry/consul/ConsulRegistry.java
@@ -84,7 +84,7 @@ public class ConsulRegistry implements ServiceRegistry {
 
             log.trace("Consul service object: {}", newService);
             consulClient.agentServiceRegister(newService, consulConfig.getToken());
-            log.debug("Registered service {}", description);
+            log.info("Registered service {}", description);
 
             return consulServiceIdentifier;
         });
@@ -97,7 +97,7 @@ public class ConsulRegistry implements ServiceRegistry {
                 log.debug("Deregistering service {}", serviceIdentifier);
                 var consulServiceIdentifier = (ConsulServiceIdentifier) serviceIdentifier;
                 consulClient.agentServiceDeregister(consulServiceIdentifier.getServiceId(), consulConfig.getToken());
-                log.debug("Deregistered service {}", serviceIdentifier);
+                log.info("Deregistered service {}", serviceIdentifier);
             });
         }
     }

--- a/nuntio-registry-consul/src/main/resources/META-INF/spring.factories
+++ b/nuntio-registry-consul/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=eu.xenit.nuntio.registry.consul.ConsulConfiguration

--- a/nuntio-registry-fake/src/main/java/eu/xenit/nuntio/registry/fake/FakeRegistryConfiguration.java
+++ b/nuntio-registry-fake/src/main/java/eu/xenit/nuntio/registry/fake/FakeRegistryConfiguration.java
@@ -1,9 +1,15 @@
 package eu.xenit.nuntio.registry.fake;
 
+import eu.xenit.nuntio.api.registry.ServiceRegistry;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 
 @Configuration
+@ConditionalOnMissingBean(ServiceRegistry.class)
+@AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
 public class FakeRegistryConfiguration {
 
     @Bean

--- a/nuntio-registry-fake/src/main/resources/META-INF/spring.factories
+++ b/nuntio-registry-fake/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=eu.xenit.nuntio.registry.fake.FakeRegistryConfiguration


### PR DESCRIPTION
- Allow the fake implementations to be wired in and enabled in production images. They can be used to debug issues with a component in production without actually affecting any real service registry.
- Add more debug logging